### PR TITLE
feat: add cairo corelib source

### DIFF
--- a/backend.dockerfile
+++ b/backend.dockerfile
@@ -1,4 +1,7 @@
-FROM node:23.7-bullseye-slim
+FROM node:20 AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
 
 WORKDIR /app
 
@@ -17,8 +20,7 @@ COPY packages/typescript-config ./packages/typescript-config
 
 RUN mkdir /app/data
 
-RUN npm install -g pnpm@9.10.0
 RUN pnpm install --frozen-lockfile
-RUN npm install -g turbo
+RUN pnpm install -g turbo
 
 CMD ["turbo", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,9 @@ services:
     restart: unless-stopped
     networks:
       - cairo_coder
-  
+
   ingester:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: ingest.dockerfile
@@ -48,4 +49,3 @@ networks:
 
 volumes:
   postgres_data:
-

--- a/ingest.dockerfile
+++ b/ingest.dockerfile
@@ -1,4 +1,7 @@
-FROM node:20
+FROM node:20 AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
 
 WORKDIR /app
 
@@ -16,15 +19,14 @@ COPY packages/agents ./packages/agents
 # Copy shared TypeScript config
 COPY packages/typescript-config ./packages/typescript-config
 
-RUN npm install -g pnpm@9.10.0
 RUN pnpm install --frozen-lockfile
-RUN npm install -g turbo
+RUN pnpm install -g turbo
 
 # Install Antora
-RUN npm install -g @antora/cli @antora/site-generator
+RUN pnpm install -g @antora/cli @antora/site-generator
 
 # Install mdbook
-RUN curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.36/mdbook-v0.4.36-x86_64-unknown-linux-gnu.tar.gz | tar xz && \
+RUN curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.48/mdbook-v0.4.48-x86_64-unknown-linux-gnu.tar.gz | tar xz && \
     mv mdbook /usr/local/bin/
 
 # Set the command to run your script

--- a/packages/agents/src/config/prompts/cairoCoderPrompts.ts
+++ b/packages/agents/src/config/prompts/cairoCoderPrompts.ts
@@ -28,6 +28,7 @@ You will be given a conversation history and a follow-up question. Your primary 
 *   **starknet_foundry:** The Starknet Foundry Documentation. For using the Foundry toolchain: writing, compiling, testing (unit tests, integration tests), and debugging Starknet contracts.
 *   **cairo_by_example:** Cairo by Example Documentation. Provides practical Cairo code snippets for specific language features or common patterns. Useful for "how-to" syntax questions.
 *   **openzeppelin_docs:** OpenZeppelin Cairo Contracts Documentation. For using the OZ library: standard implementations (ERC20, ERC721), access control, security patterns, contract upgradeability. Crucial for building standard-compliant contracts.
+*   **corelib_docs:** Cairo Core Library Documentation. For using the Cairo core library: basic types, stdlib functions, stdlib structs, macros, and other core concepts. Essential for Cairo programming questions.
 
 **Examples:**
 

--- a/packages/agents/src/types/index.ts
+++ b/packages/agents/src/types/index.ts
@@ -102,6 +102,7 @@ export enum DocumentSource {
   STARKNET_FOUNDRY = 'starknet_foundry',
   CAIRO_BY_EXAMPLE = 'cairo_by_example',
   OPENZEPPELIN_DOCS = 'openzeppelin_docs',
+  CORELIB_DOCS = 'corelib_docs',
 }
 
 export type BookChunk = {

--- a/packages/ingester/src/IngesterFactory.ts
+++ b/packages/ingester/src/IngesterFactory.ts
@@ -50,9 +50,9 @@ export class IngesterFactory {
 
       case 'corelib_docs':
         const {
-          CorelibDocsIngester,
-        } = require('./ingesters/CorelibDocsIngester');
-        return new CorelibDocsIngester();
+          CoreLibDocsIngester,
+        } = require('./ingesters/CoreLibDocsIngester');
+        return new CoreLibDocsIngester();
 
       default:
         throw new Error(`Unsupported source: ${source}`);

--- a/packages/ingester/src/IngesterFactory.ts
+++ b/packages/ingester/src/IngesterFactory.ts
@@ -48,6 +48,12 @@ export class IngesterFactory {
         } = require('./ingesters/OpenZeppelinDocsIngester');
         return new OpenZeppelinDocsIngester();
 
+      case 'corelib_docs':
+        const {
+          CorelibDocsIngester,
+        } = require('./ingesters/CorelibDocsIngester');
+        return new CorelibDocsIngester();
+
       default:
         throw new Error(`Unsupported source: ${source}`);
     }
@@ -65,6 +71,7 @@ export class IngesterFactory {
       DocumentSource.STARKNET_FOUNDRY,
       DocumentSource.CAIRO_BY_EXAMPLE,
       DocumentSource.OPENZEPPELIN_DOCS,
+      DocumentSource.CORELIB_DOCS,
     ];
   }
 }

--- a/packages/ingester/src/ingesters/CoreLibDocsIngester.ts
+++ b/packages/ingester/src/ingesters/CoreLibDocsIngester.ts
@@ -1,13 +1,9 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import axios from 'axios';
-import AdmZip from 'adm-zip';
-import { Document } from '@langchain/core/documents';
 import {
-  BookChunk,
   DocumentSource,
 } from '@cairo-coder/agents/types/index';
-import { BookConfig, BookPageDto, ParsedSection } from '../utils/types';
+import { BookConfig, BookPageDto } from '../utils/types';
 import { processDocFiles } from '../utils/fileUtils';
 import { logger } from '@cairo-coder/agents/utils/index';
 import { exec as execCallback } from 'child_process';

--- a/packages/ingester/src/ingesters/CoreLibDocsIngester.ts
+++ b/packages/ingester/src/ingesters/CoreLibDocsIngester.ts
@@ -1,0 +1,116 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import axios from 'axios';
+import AdmZip from 'adm-zip';
+import { Document } from '@langchain/core/documents';
+import {
+  BookChunk,
+  DocumentSource,
+} from '@cairo-coder/agents/types/index';
+import { BookConfig, BookPageDto, ParsedSection } from '../utils/types';
+import { processDocFiles } from '../utils/fileUtils';
+import { logger } from '@cairo-coder/agents/utils/index';
+import { exec as execCallback } from 'child_process';
+import { promisify } from 'util';
+import { MarkdownIngester } from './MarkdownIngester';
+
+/**
+ * Ingester for the Cairo Book documentation
+ *
+ * This ingester downloads the Cairo Book documentation from GitHub releases,
+ * processes the markdown files, and creates chunks for the vector store.
+ */
+export class CoreLibDocsIngester extends MarkdownIngester {
+  /**
+   * Constructor for the Cairo Book ingester
+   */
+  constructor() {
+    // Define the configuration for the Cairo Book
+    // TODO update with starkware repo once fixed
+    const config: BookConfig = {
+      repoOwner: 'enitrat',
+      repoName: 'cairo-docs',
+      fileExtension: '.md',
+      chunkSize: 4096,
+      chunkOverlap: 512,
+    };
+
+    super(config, DocumentSource.CORELIB_DOCS);
+  }
+
+  /**
+   * Get the directory path for extracting files
+   *
+   * @returns string - Path to the extract directory
+   */
+  protected getExtractDir(): string {
+    return path.join(__dirname, '..', '..', 'temp', 'corelib-docs');
+  }
+
+  /**
+   * Download and extract the repository
+   *
+   * @param extractDir - The directory to extract to
+   */
+  protected async downloadAndExtractDocs(): Promise<BookPageDto[]> {
+    const extractDir = this.getExtractDir();
+    const repoUrl = `https://github.com/${this.config.repoOwner}/${this.config.repoName}.git`;
+
+    logger.info(`Cloning repository from ${repoUrl}`);
+
+    // Clone the repository
+    const exec = promisify(execCallback);
+    try {
+      await exec(`git clone ${repoUrl} ${extractDir}`);
+    } catch (error) {
+      logger.error('Error cloning repository:', error);
+      throw new Error('Failed to clone repository');
+    }
+
+    // Navigate to the core directory
+    const coreDir = path.join(extractDir, 'core');
+
+    // Update book.toml configuration
+    const bookTomlPath = path.join(coreDir, 'book.toml');
+
+    try {
+      let bookToml = await fs.readFile(bookTomlPath, 'utf8');
+
+      // Add [output.markdown] if it doesn't exist
+      if (!bookToml.includes('[output.markdown]')) {
+        bookToml += '\n[output.markdown]\n';
+      }
+
+      await fs.writeFile(bookTomlPath, bookToml);
+      logger.info('Updated book.toml configuration');
+    } catch (error) {
+      logger.error('Error updating book.toml:', error);
+      throw new Error('Failed to update book.toml configuration');
+    }
+
+    // Build the mdbook
+    try {
+      logger.info('Building mdbook...');
+      try {
+        await exec('mdbook --version');
+      } catch (error) {
+        logger.error('mdbook is not installed on this system');
+        throw new Error('mdbook is required but not installed');
+      }
+
+      await exec('mdbook build', { cwd: coreDir });
+      logger.info('mdbook built successfully');
+    } catch (error) {
+      logger.error('Error building mdbook:', error);
+      throw new Error('Failed to build mdbook');
+    }
+
+    logger.info('Repository cloned and processed successfully.');
+
+    // Process the markdown files
+    const srcDir = path.join(coreDir, 'book/markdown');
+    const pages = await processDocFiles(this.config, srcDir);
+
+    return pages;
+  }
+}


### PR DESCRIPTION
Adds https://docs.cairo-lang.org/core as content source, making it better at using corelib stuff for context-specific operations (like using eth-related modules, ec operations, etc)