### PR TITLE
fix: race condition on VectorDb singleton aquisition

### DIFF
--- a/packages/agents/src/config/settings.ts
+++ b/packages/agents/src/config/settings.ts
@@ -41,6 +41,7 @@ export const getVectorDbConfig = (): VectorStoreConfig => {
     POSTGRES_DB: process.env.POSTGRES_DB || 'cairocoder',
     POSTGRES_HOST: process.env.POSTGRES_HOST || 'postgres',
     POSTGRES_PORT: process.env.POSTGRES_PORT || '5432',
+    POSTGRES_TABLE_NAME: process.env.POSTGRES_TABLE_NAME || 'documents',
   };
 };
 

--- a/packages/agents/src/types/index.ts
+++ b/packages/agents/src/types/index.ts
@@ -16,6 +16,7 @@ export interface VectorStoreConfig {
   POSTGRES_DB: string;
   POSTGRES_HOST: string;
   POSTGRES_PORT: string;
+  POSTGRES_TABLE_NAME: string;
 }
 
 export interface AgentPrompts {


### PR DESCRIPTION
fixes race condition by ensuring the class attribute is not set until the DB table is properly created.
also ensures that the init operation is done only once by adding an `initializing` Promise flag that only resolves once the first init has finished.