### PR TITLE
feat: store chunk sourceMap when available

### DIFF
--- a/packages/ingester/__tests__/StarknetDocsIngester.test.ts
+++ b/packages/ingester/__tests__/StarknetDocsIngester.test.ts
@@ -17,6 +17,9 @@ describe('StarknetDocsIngester', () => {
       fileExtension: '.mdx',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://docs.starknet.io',
+      urlSuffix: '',
+      useUrlMapping: true,
     });
     // @ts-ignore - accessing protected property for testing
     expect(ingester.source).toBe(DocumentSource.STARKNET_DOCS);

--- a/packages/ingester/__tests__/vectorStoreUtils.test.ts
+++ b/packages/ingester/__tests__/vectorStoreUtils.test.ts
@@ -1,38 +1,115 @@
+import { BookChunk, DocumentSource } from '@cairo-coder/agents';
 import { findChunksToUpdateAndRemove } from '../src/utils/vectorStoreUtils';
 import { Document } from '@langchain/core/documents';
 
 describe('findChunksToUpdateAndRemove', () => {
   it('should correctly identify chunks to update and remove', () => {
-    const freshChunks: Document<Record<string, any>>[] = [
+    const freshChunks: Document<BookChunk>[] = [
       {
-        metadata: { uniqueId: '1', contentHash: 'hash1' },
+        metadata: {
+          name: '1',
+          title: '1',
+          chunkNumber: 1,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '1',
+          contentHash: 'hash1',
+          sourceLink: 'https://example.com/1',
+        },
         pageContent: 'Some Content 1',
       },
       {
-        metadata: { uniqueId: '2', contentHash: 'hash2_updated' },
+        metadata: {
+          name: '2',
+          title: '2',
+          chunkNumber: 2,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '2',
+          contentHash: 'hash2_updated',
+          sourceLink: 'https://example.com/2',
+        },
         pageContent: 'Some Content 2',
       },
       {
-        metadata: { uniqueId: '4', contentHash: 'hash4' },
+        metadata: {
+          name: '4',
+          title: '4',
+          chunkNumber: 4,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '4',
+          contentHash: 'hash4',
+          sourceLink: 'https://example.com/4',
+        },
         pageContent: 'Some Content 3',
       },
     ];
 
     const storedChunkHashes = [
-      { uniqueId: '1', contentHash: 'hash1' },
-      { uniqueId: '2', contentHash: 'hash2' },
-      { uniqueId: '3', contentHash: 'hash3' },
+      {
+        uniqueId: '1',
+        contentHash: 'hash1',
+        metadata: {
+          name: '1',
+          title: '1',
+          chunkNumber: 1,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '1',
+          contentHash: 'hash1',
+          sourceLink: 'https://example.com/1',
+        },
+      },
+      {
+        uniqueId: '2',
+        contentHash: 'hash2',
+        metadata: {
+          name: '2',
+          title: '2',
+          chunkNumber: 2,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '2',
+          contentHash: 'hash2',
+          sourceLink: 'https://example.com/2',
+        },
+      },
+      {
+        uniqueId: '3',
+        contentHash: 'hash3',
+        metadata: {
+          name: '3',
+          title: '3',
+          chunkNumber: 3,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '3',
+          contentHash: 'hash3',
+          sourceLink: 'https://example.com/3',
+        },
+      },
     ];
 
     const result = findChunksToUpdateAndRemove(freshChunks, storedChunkHashes);
 
     expect(result.chunksToUpdate).toEqual([
       {
-        metadata: { uniqueId: '2', contentHash: 'hash2_updated' },
+        metadata: {
+          name: '2',
+          title: '2',
+          chunkNumber: 2,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '2',
+          contentHash: 'hash2_updated',
+          sourceLink: 'https://example.com/2',
+        },
         pageContent: 'Some Content 2',
       },
       {
-        metadata: { uniqueId: '4', contentHash: 'hash4' },
+        metadata: {
+          name: '4',
+          title: '4',
+          chunkNumber: 4,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '4',
+          contentHash: 'hash4',
+          sourceLink: 'https://example.com/4',
+        },
         pageContent: 'Some Content 3',
       },
     ]);
@@ -40,20 +117,58 @@ describe('findChunksToUpdateAndRemove', () => {
   });
 
   it('should return empty arrays when no updates or removals are needed', () => {
-    const freshChunks: Document<Record<string, any>>[] = [
+    const freshChunks: Document<BookChunk>[] = [
       {
-        metadata: { uniqueId: '1', contentHash: 'hash1' },
         pageContent: 'Some Content 1',
+        metadata: {
+          name: '1',
+          title: '1',
+          chunkNumber: 1,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '1',
+          contentHash: 'hash1',
+          sourceLink: 'https://example.com/1',
+        },
       },
       {
-        metadata: { uniqueId: '2', contentHash: 'hash2' },
         pageContent: 'Some Content 2',
+        metadata: {
+          name: '2',
+          title: '2',
+          chunkNumber: 2,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '2',
+          contentHash: 'hash2',
+          sourceLink: 'https://example.com/2',
+        },
       },
     ];
 
     const storedChunkHashes = [
-      { uniqueId: '1', contentHash: 'hash1' },
-      { uniqueId: '2', contentHash: 'hash2' },
+      {
+        uniqueId: '1',
+        metadata: {
+          name: '1',
+          title: '1',
+          chunkNumber: 1,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '1',
+          contentHash: 'hash1',
+          sourceLink: 'https://example.com/1',
+        },
+      },
+      {
+        uniqueId: '2',
+        metadata: {
+          name: '2',
+          title: '2',
+          chunkNumber: 2,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '2',
+          contentHash: 'hash2',
+          sourceLink: 'https://example.com/2',
+        },
+      },
     ];
 
     const result = findChunksToUpdateAndRemove(freshChunks, storedChunkHashes);
@@ -66,6 +181,57 @@ describe('findChunksToUpdateAndRemove', () => {
     const result = findChunksToUpdateAndRemove([], []);
 
     expect(result.chunksToUpdate).toEqual([]);
+    expect(result.chunksToRemove).toEqual([]);
+  });
+
+  it('should detect metadata changes even when content hash is the same', () => {
+    const freshChunks: Document<BookChunk>[] = [
+      {
+        metadata: {
+          name: '1',
+          title: 'Updated Title',
+          chunkNumber: 1,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '1',
+          contentHash: 'hash1',
+          sourceLink: 'https://example.com/1-updated',
+        },
+        pageContent: 'Some Content 1',
+      },
+    ];
+
+    const storedChunkHashes = [
+      {
+        uniqueId: '1',
+        metadata: {
+          name: '1',
+          title: 'Original Title',
+          chunkNumber: 1,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '1',
+          contentHash: 'hash1',
+          sourceLink: 'https://example.com/1',
+        },
+      },
+    ];
+
+    const result = findChunksToUpdateAndRemove(freshChunks, storedChunkHashes);
+
+    // Should update because metadata changed (sourceLink and title)
+    expect(result.chunksToUpdate).toEqual([
+      {
+        metadata: {
+          name: '1',
+          title: 'Updated Title',
+          chunkNumber: 1,
+          source: DocumentSource.CAIRO_BOOK,
+          uniqueId: '1',
+          contentHash: 'hash1',
+          sourceLink: 'https://example.com/1-updated',
+        },
+        pageContent: 'Some Content 1',
+      },
+    ]);
     expect(result.chunksToRemove).toEqual([]);
   });
 });

--- a/packages/ingester/src/generateEmbeddings.ts
+++ b/packages/ingester/src/generateEmbeddings.ts
@@ -186,5 +186,7 @@ async function main() {
   }
 }
 
-// Run the main function
-main();
+// Run the main function only when this file is executed directly
+if (require.main === module) {
+  main();
+}

--- a/packages/ingester/src/ingesters/CairoBookIngester.ts
+++ b/packages/ingester/src/ingesters/CairoBookIngester.ts
@@ -34,6 +34,9 @@ export class CairoBookIngester extends MarkdownIngester {
       fileExtension: '.md',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://book.cairo-lang.org',
+      urlSuffix: '.html',
+      useUrlMapping: false,
     };
 
     super(config, DocumentSource.CAIRO_BOOK);
@@ -104,7 +107,7 @@ export class CairoBookIngester extends MarkdownIngester {
           chunkNumber: chunk.meta.chunkNumber, // Already 0-based
           contentHash: contentHash,
           uniqueId: chunk.meta.uniqueId,
-          sourceLink: '',
+          sourceLink: this.config.baseUrl,
           source: this.source,
         },
       });

--- a/packages/ingester/src/ingesters/CairoByExampleIngester.ts
+++ b/packages/ingester/src/ingesters/CairoByExampleIngester.ts
@@ -21,6 +21,9 @@ export class CairoByExampleIngester extends MarkdownIngester {
       fileExtension: '.md',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://enitrat.github.io/cairo-by-example/index.html',
+      urlSuffix: '.html',
+      useUrlMapping: false,
     };
 
     super(config, DocumentSource.CAIRO_BY_EXAMPLE);

--- a/packages/ingester/src/ingesters/CoreLibDocsIngester.ts
+++ b/packages/ingester/src/ingesters/CoreLibDocsIngester.ts
@@ -25,11 +25,14 @@ export class CoreLibDocsIngester extends MarkdownIngester {
   constructor() {
     // Define the configuration for the Cairo Core Library
     const config: BookConfig = {
-      repoOwner: 'starkware-libs',
+      repoOwner: 'enitrat',
       repoName: 'cairo-docs',
       fileExtension: '.md',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://docs.starknet.io/build/corelib/intro',
+      urlSuffix: '',
+      useUrlMapping: false,
     };
 
     super(config, DocumentSource.CORELIB_DOCS);
@@ -104,7 +107,7 @@ export class CoreLibDocsIngester extends MarkdownIngester {
           chunkNumber: chunk.meta.chunkNumber, // Already 0-based
           contentHash: contentHash,
           uniqueId: chunk.meta.uniqueId,
-          sourceLink: '',
+          sourceLink: this.config.baseUrl,
           source: this.source,
         },
       });

--- a/packages/ingester/src/ingesters/MarkdownIngester.ts
+++ b/packages/ingester/src/ingesters/MarkdownIngester.ts
@@ -123,6 +123,23 @@ export abstract class MarkdownIngester extends BaseIngester {
     // Create a document for each section
     sections.forEach((section: ParsedSection, index: number) => {
       const hash: string = calculateHash(section.content);
+
+      // If a baseUrl is provided in the config, build a source link.
+      // If useUrlMapping is true, map to specific page URLs with anchors.
+      // If useUrlMapping is false, only use the baseUrl.
+      const hasBase = !!this.config.baseUrl;
+      let sourceLink = '';
+
+      if (this.config.useUrlMapping) {
+        // Map to specific page URLs with anchors
+        const anchor = section.anchor || createAnchor(section.title);
+        const urlSuffix = this.config.urlSuffix ?? '';
+        sourceLink = `${this.config.baseUrl}/${page_name}${urlSuffix}${anchor ? `#${anchor}` : ''}`;
+      } else {
+        // Only use the baseUrl
+        sourceLink = this.config.baseUrl;
+      }
+
       localChunks.push(
         new Document<BookChunk>({
           pageContent: section.content,
@@ -132,7 +149,7 @@ export abstract class MarkdownIngester extends BaseIngester {
             chunkNumber: index,
             contentHash: hash,
             uniqueId: `${page_name}-${index}`,
-            sourceLink: ``,
+            sourceLink,
             source: this.source,
           },
         }),

--- a/packages/ingester/src/ingesters/OpenZeppelinDocsIngester.ts
+++ b/packages/ingester/src/ingesters/OpenZeppelinDocsIngester.ts
@@ -30,6 +30,9 @@ export class OpenZeppelinDocsIngester extends MarkdownIngester {
       fileExtension: '.md',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://docs.openzeppelin.com/contracts-cairo',
+      urlSuffix: '',
+      useUrlMapping: false,
     };
 
     super(config, DocumentSource.OPENZEPPELIN_DOCS);
@@ -104,7 +107,7 @@ export class OpenZeppelinDocsIngester extends MarkdownIngester {
           chunkNumber: chunk.meta.chunkNumber, // Already 0-based
           contentHash: contentHash,
           uniqueId: chunk.meta.uniqueId,
-          sourceLink: '',
+          sourceLink: this.config.baseUrl,
           source: this.source,
         },
       });

--- a/packages/ingester/src/ingesters/ScarbDocsIngester.ts
+++ b/packages/ingester/src/ingesters/ScarbDocsIngester.ts
@@ -26,6 +26,9 @@ export class ScarbDocsIngester extends MarkdownIngester {
       fileExtension: '.md',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://docs.swmansion.com/scarb/docs',
+      urlSuffix: '.html',
+      useUrlMapping: true,
     };
 
     super(config, DocumentSource.SCARB_DOCS);

--- a/packages/ingester/src/ingesters/StarknetDocsIngester.ts
+++ b/packages/ingester/src/ingesters/StarknetDocsIngester.ts
@@ -36,6 +36,9 @@ export class StarknetDocsIngester extends MarkdownIngester {
       fileExtension: '.mdx',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://docs.starknet.io',
+      urlSuffix: '',
+      useUrlMapping: true,
     };
 
     super(config, DocumentSource.STARKNET_DOCS);

--- a/packages/ingester/src/ingesters/StarknetFoundryIngester.ts
+++ b/packages/ingester/src/ingesters/StarknetFoundryIngester.ts
@@ -30,6 +30,9 @@ export class StarknetFoundryIngester extends MarkdownIngester {
       fileExtension: '.md',
       chunkSize: 4096,
       chunkOverlap: 512,
+      baseUrl: 'https://foundry-rs.github.io/starknet-foundry',
+      urlSuffix: '.html',
+      useUrlMapping: true,
     };
 
     super(config, DocumentSource.STARKNET_FOUNDRY);

--- a/packages/ingester/src/utils/types.ts
+++ b/packages/ingester/src/utils/types.ts
@@ -38,6 +38,15 @@ export type BookConfig = {
 
   /** The overlap between chunks in characters */
   chunkOverlap: number;
+
+  /** Base URL of the public docs site for link mapping */
+  baseUrl: string;
+
+  /** URL suffix (e.g., '.html') appended to page paths */
+  urlSuffix: string;
+
+  /** Whether to map pages to URLs or just use the baseUrl. */
+  useUrlMapping: boolean;
 };
 
 /**


### PR DESCRIPTION
For ingesters that have the possibility to map a chunk to an online source, store the corresponding sourceLink.