### PR TITLE
feat(summarizer): support from summarizing from crawled website

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "tenacity>=8.0.0",
   "toml>=0.10.2",
   "tqdm>=4.66.0",
+  "typer>=0.19.2",
 ]
 
 [project.optional-dependencies]

--- a/python/src/scripts/docs_crawler.py
+++ b/python/src/scripts/docs_crawler.py
@@ -20,8 +20,8 @@ from tqdm.asyncio import tqdm
 # Configuration
 UA = "NotebookLM-prep-crawler/1.1 (+contact: you@example.com)"
 OUT_FILE = Path("doc_dump")
-CONCURRENCY = 6
-MAX_RETRIES = 3
+CONCURRENCY = 4  # Reduced from 6 to avoid rate limits
+MAX_RETRIES = 5
 TIMEOUT = 30
 MAX_CRAWL_PAGES = 100
 
@@ -31,7 +31,7 @@ EXCLUDE_PATTERNS = [
     r'/author/', r'/user/', r'/wp-admin', r'/wp-content', r'/wp-includes',
     r'/_next/', r'/static/', r'/assets/', r'/js/', r'/css/', r'/images/',
     r'/feed', r'/rss', r'/atom', r'/sitemap', r'/robots\.txt',
-    r'mailto:', r'tel:', r'/#'
+    r'mailto:', r'tel:', r'/#', r'\.css$'
 ]
 
 # Common documentation content selectors
@@ -359,17 +359,9 @@ class DocsCrawler:
                     ""
                 ])
             else:
+                # Skip pages that failed to fetch or returned non-HTML content
                 error = page_data.get('error', 'Unknown error')
-                lines.extend([
-                    f"**Source URL:** {url}",
-                    "",
-                    f"## {url}",
-                    "",
-                    f"*Failed to fetch: {error}*",
-                    "",
-                    "---",
-                    ""
-                ])
+                logger.info(f"Skipping {url}: {error}")
 
         return '\n'.join(lines)
 

--- a/python/src/scripts/summarizer/doc_dump_summarizer.py
+++ b/python/src/scripts/summarizer/doc_dump_summarizer.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import structlog
+
+from .base_summarizer import BaseSummarizer
+from .dpsy_summarizer import (
+    configure_dspy,
+    make_chunks,
+    massively_summarize,
+    generate_markdown_toc,
+)
+
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class _DocPage:
+    url: str
+    content: str
+
+
+class DocDumpSummarizer(BaseSummarizer):
+    """Summarizer that reads a single doc-dump markdown file (with repeated '**Source URL:** ...' sections)
+    and produces a hierarchical summary with per-section source URL lists.
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+        self._pages: List[_DocPage] = []
+
+    def clone_repository(self) -> Path:
+        """No-op clone for local files: return CWD as a base path."""
+        return Path.cwd()
+
+    def build_documentation(self, repo_path: Path) -> Path:
+        """Treat repo_url as a path to the doc_dump markdown file."""
+        doc_path = Path(self.config.repo_url)
+        if not doc_path.exists():
+            raise RuntimeError(f"Doc dump file not found: {doc_path}")
+        if doc_path.suffix.lower() not in (".md", ".markdown"):
+            logger.warning(f"Provided path does not look like markdown: {doc_path}")
+        return doc_path
+
+    def extract_and_merge_content(self, docs_path: Path) -> str:
+        """Read and parse the doc dump into pages; return the raw text for optional downstream use."""
+        text = docs_path.read_text()
+        self._pages = self._parse_doc_dump(text)
+        logger.info(f"Parsed {len(self._pages)} pages from doc dump")
+        return text
+
+    def summarize_content(self, content: str) -> str:
+        """Chunk per page with URL metadata, summarize, then insert ToC and per-section sources."""
+        if not self._pages:
+            self._pages = self._parse_doc_dump(content)
+
+        # Configure DSPy
+        configure_dspy()
+
+        # Build chunks and parallel metadata
+        chunks: List[str] = []
+        metas: List[dict] = []
+        for page in self._pages:
+            page_chunks = make_chunks(page.content, target_chunk_size=2000)
+            chunks.extend(page_chunks)
+            metas.extend({"source_url": page.url} for _ in page_chunks)
+
+        if not chunks:
+            raise RuntimeError("No chunks produced from doc dump")
+
+        # Title from first page base
+        title = self._infer_title(self._pages)
+        logger.info(f"Summarizing {len(chunks)} chunks from doc dump into {self.config.output_path}")
+
+        summary = massively_summarize(toc_path=[title], chunks=chunks, metas=metas)
+
+        # Insert a Table of Contents below the top title
+        lines = summary.splitlines()
+        if lines and lines[0].lstrip().startswith('#'):
+            toc_md = generate_markdown_toc(summary, toc_path=[title], max_level=3)
+            insertion = ["", "## Table of Contents", "", toc_md, ""] if toc_md else []
+            if insertion:
+                summary = "\n".join([lines[0]] + insertion + lines[1:])
+
+        return summary
+
+    # Helpers
+    @staticmethod
+    def _parse_doc_dump(text: str) -> List[_DocPage]:
+        """Split the doc dump by '**Source URL:**' markers and return pages."""
+        # Find all '**Source URL:** <url>' markers
+        pattern = re.compile(r"^\*\*Source URL:\*\*\s+(\S+)", re.MULTILINE)
+        pages: List[_DocPage] = []
+        matches = list(pattern.finditer(text))
+        for i, m in enumerate(matches):
+            url = m.group(1)
+            start = m.end()
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            # Trim surrounding '---' separators and whitespace
+            content = text[start:end].strip()
+            content = DocDumpSummarizer._strip_leading_trailing_separators(content)
+            pages.append(_DocPage(url=url, content=content))
+        return pages
+
+    @staticmethod
+    def _strip_leading_trailing_separators(s: str) -> str:
+        lines = [ln for ln in s.splitlines()]
+        # remove leading/trailing lines that are just '---'
+        while lines and lines[0].strip() == '---':
+            lines.pop(0)
+        while lines and lines[-1].strip() == '---':
+            lines.pop()
+        return "\n".join(lines).strip()
+
+    @staticmethod
+    def _infer_title(pages: List[_DocPage]) -> str:
+        if not pages:
+            return "# Documentation Summary"
+        first = pages[0].url.rstrip('/')
+        # Use last path segment as name
+        seg = first.split('/')[-1] or "documentation"
+        name = seg.replace('-', ' ').title()
+        return f"# {name} Documentation Summary"
+

--- a/python/src/scripts/summarizer/doc_dump_summarizer.py
+++ b/python/src/scripts/summarizer/doc_dump_summarizer.py
@@ -3,18 +3,16 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 import structlog
 
 from .base_summarizer import BaseSummarizer
 from .dpsy_summarizer import (
     configure_dspy,
+    generate_markdown_toc,
     make_chunks,
     massively_summarize,
-    generate_markdown_toc,
 )
-
 
 logger = structlog.get_logger(__name__)
 
@@ -32,7 +30,7 @@ class DocDumpSummarizer(BaseSummarizer):
 
     def __init__(self, config):
         super().__init__(config)
-        self._pages: List[_DocPage] = []
+        self._pages: list[_DocPage] = []
 
     def clone_repository(self) -> Path:
         """No-op clone for local files: return CWD as a base path."""
@@ -63,8 +61,8 @@ class DocDumpSummarizer(BaseSummarizer):
         configure_dspy()
 
         # Build chunks and parallel metadata
-        chunks: List[str] = []
-        metas: List[dict] = []
+        chunks: list[str] = []
+        metas: list[dict] = []
         for page in self._pages:
             page_chunks = make_chunks(page.content, target_chunk_size=2000)
             chunks.extend(page_chunks)
@@ -91,11 +89,11 @@ class DocDumpSummarizer(BaseSummarizer):
 
     # Helpers
     @staticmethod
-    def _parse_doc_dump(text: str) -> List[_DocPage]:
+    def _parse_doc_dump(text: str) -> list[_DocPage]:
         """Split the doc dump by '**Source URL:**' markers and return pages."""
         # Find all '**Source URL:** <url>' markers
         pattern = re.compile(r"^\*\*Source URL:\*\*\s+(\S+)", re.MULTILINE)
-        pages: List[_DocPage] = []
+        pages: list[_DocPage] = []
         matches = list(pattern.finditer(text))
         for i, m in enumerate(matches):
             url = m.group(1)
@@ -109,7 +107,7 @@ class DocDumpSummarizer(BaseSummarizer):
 
     @staticmethod
     def _strip_leading_trailing_separators(s: str) -> str:
-        lines = [ln for ln in s.splitlines()]
+        lines = list(s.splitlines())
         # remove leading/trailing lines that are just '---'
         while lines and lines[0].strip() == '---':
             lines.pop(0)
@@ -118,7 +116,7 @@ class DocDumpSummarizer(BaseSummarizer):
         return "\n".join(lines).strip()
 
     @staticmethod
-    def _infer_title(pages: List[_DocPage]) -> str:
+    def _infer_title(pages: list[_DocPage]) -> str:
         if not pages:
             return "# Documentation Summary"
         first = pages[0].url.rstrip('/')

--- a/python/src/scripts/summarizer/dpsy_summarizer.py
+++ b/python/src/scripts/summarizer/dpsy_summarizer.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 from collections import Counter
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Optional
 
 import dotenv
 import dspy
@@ -68,7 +68,7 @@ def group_sections(topics, chunks, headers):
         sections[topic.topic].append(chunk)
     return sections
 
-def summarize_sections(toc_path, sections: Dict[str, List[str]], sections_metas: Optional[Dict[str, List[Optional[dict]]]] = None):
+def summarize_sections(toc_path, sections: dict[str, list[str]], sections_metas: Optional[dict[str, list[Optional[dict]]]] = None):
     parallelizer = DSPyParallel(num_threads=12)
     tasks = []
     for topic, section_chunks in sections.items():
@@ -76,7 +76,7 @@ def summarize_sections(toc_path, sections: Dict[str, List[str]], sections_metas:
         tasks.append((massively_summarize, {"toc_path": toc_path + [topic], "chunks": section_chunks, "metas": metas}))
     return parallelizer(tasks)
 
-def _aggregate_source_urls(metas: Optional[List[Optional[dict]]]) -> List[str]:
+def _aggregate_source_urls(metas: Optional[list[Optional[dict]]]) -> list[str]:
     """Aggregate and order source URLs by frequency (descending)."""
     if not metas:
         return []
@@ -92,17 +92,17 @@ def _aggregate_source_urls(metas: Optional[List[Optional[dict]]]) -> List[str]:
     return [url for url, _ in ordered]
 
 
-def _format_sources_block(urls: List[str]) -> str:
+def _format_sources_block(urls: list[str]) -> str:
     if not urls:
         return ""
     bullets = "\n".join(f"- {u}" for u in urls)
     return f"---\n\nSources:\n\n{bullets}\n\n---\n\n"
 
 
-def _group_sections_with_metas(topics, chunks: List[str], headers: List[str], metas: Optional[List[Optional[dict]]]):
+def _group_sections_with_metas(topics, chunks: list[str], headers: list[str], metas: Optional[list[Optional[dict]]]):
     """Return (sections, sections_metas) grouped by topic."""
-    sections: Dict[str, List[str]] = {topic: [] for topic in headers}
-    sections_metas: Dict[str, List[Optional[dict]]] = {topic: [] for topic in headers}
+    sections: dict[str, list[str]] = {topic: [] for topic in headers}
+    sections_metas: dict[str, list[Optional[dict]]] = {topic: [] for topic in headers}
     for topic, chunk, meta in zip(topics, chunks, metas or [None] * len(chunks), strict=False):
         sections[topic.topic].append(chunk)
         sections_metas[topic.topic].append(meta)
@@ -111,8 +111,8 @@ def _group_sections_with_metas(topics, chunks: List[str], headers: List[str], me
 
 def massively_summarize(
     toc_path: list | str,
-    chunks: List[str],
-    metas: Optional[List[Optional[dict]]] = None,
+    chunks: list[str],
+    metas: Optional[list[Optional[dict]]] = None,
 ):
     # Normalize metas length
     if metas is None:
@@ -127,8 +127,7 @@ def massively_summarize(
             # section = f"{title}\n\nNo content generated for this section."
             logger.warning(f"No content generated for this section: {title}")
             return ""
-        else:
-            section = f"{content}"
+        section = f"{content}"
         urls = _aggregate_source_urls(metas)
         sources_block = _format_sources_block(urls)
         header = (sources_block if sources_block else "")

--- a/python/src/scripts/summarizer/dpsy_summarizer.py
+++ b/python/src/scripts/summarizer/dpsy_summarizer.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import re
+from collections import Counter
+from typing import Any, Dict, List, Optional, Tuple
 
 import dotenv
 import dspy
@@ -46,7 +48,7 @@ class WriteSection(dspy.Signature):
     section_content: str = dspy.OutputField()
 
 def produce_gist(toc_path, chunks):
-    parallelizer = DSPyParallel(num_threads=5)
+    parallelizer = DSPyParallel(num_threads=12)
     produce_gist = dspy.ChainOfThought(ProduceGist)
     chunk_summaries = parallelizer([(produce_gist, {"toc_path": toc_path, "chunk": chunk}) for chunk in chunks])
     return [summary.gist for summary in chunk_summaries]
@@ -56,7 +58,7 @@ def produce_headers(toc_path, chunk_summaries):
     return produce_headers(toc_path=toc_path, chunk_summaries=chunk_summaries).headers
 
 def classify_chunks(toc_path, chunks, headers):
-    parallelizer = DSPyParallel(num_threads=5)
+    parallelizer = DSPyParallel(num_threads=12)
     classify = dspy.ChainOfThought(make_signature(f"toc_path: list[str], chunk -> topic: Literal{headers}"))
     return parallelizer([(classify, {"toc_path": toc_path, "chunk": chunk}) for chunk in chunks])
 
@@ -66,33 +68,89 @@ def group_sections(topics, chunks, headers):
         sections[topic.topic].append(chunk)
     return sections
 
-def summarize_sections(toc_path, sections):
-    parallelizer = DSPyParallel(num_threads=5)
-    return parallelizer([
-        (massively_summarize, {"toc_path": toc_path + [topic], "chunks": section_chunks})
-        for topic, section_chunks in sections.items()
-    ])
+def summarize_sections(toc_path, sections: Dict[str, List[str]], sections_metas: Optional[Dict[str, List[Optional[dict]]]] = None):
+    parallelizer = DSPyParallel(num_threads=12)
+    tasks = []
+    for topic, section_chunks in sections.items():
+        metas = sections_metas.get(topic) if sections_metas else None
+        tasks.append((massively_summarize, {"toc_path": toc_path + [topic], "chunks": section_chunks, "metas": metas}))
+    return parallelizer(tasks)
+
+def _aggregate_source_urls(metas: Optional[List[Optional[dict]]]) -> List[str]:
+    """Aggregate and order source URLs by frequency (descending)."""
+    if not metas:
+        return []
+    counter: Counter[str] = Counter()
+    for m in metas:
+        if not m:
+            continue
+        url = m.get("source_url")
+        if url:
+            counter[url] += 1
+    # Sort by count desc, then by URL for stability
+    ordered = sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [url for url, _ in ordered]
+
+
+def _format_sources_block(urls: List[str]) -> str:
+    if not urls:
+        return ""
+    bullets = "\n".join(f"- {u}" for u in urls)
+    return f"---\n\nSources:\n\n{bullets}\n\n---\n\n"
+
+
+def _group_sections_with_metas(topics, chunks: List[str], headers: List[str], metas: Optional[List[Optional[dict]]]):
+    """Return (sections, sections_metas) grouped by topic."""
+    sections: Dict[str, List[str]] = {topic: [] for topic in headers}
+    sections_metas: Dict[str, List[Optional[dict]]] = {topic: [] for topic in headers}
+    for topic, chunk, meta in zip(topics, chunks, metas or [None] * len(chunks), strict=False):
+        sections[topic.topic].append(chunk)
+        sections_metas[topic.topic].append(meta)
+    return sections, sections_metas
+
 
 def massively_summarize(
     toc_path: list | str,
-    chunks: list[str],
+    chunks: List[str],
+    metas: Optional[List[Optional[dict]]] = None,
 ):
+    # Normalize metas length
+    if metas is None:
+        metas = [None] * len(chunks)
+
+    title = toc_path[-1]
+
+    # Base case: small batch or deep depth → write a single section
     if len(chunks) < 5 or len(toc_path) >= 3:
         content = dspy.ChainOfThought(WriteSection)(toc_path=toc_path, content_chunks=chunks).section_content
         if content is None:
-            return f"{toc_path[-1]}\n\nNo content generated for this section."
-        return f"{toc_path[-1]}\n\n{content}"
+            # section = f"{title}\n\nNo content generated for this section."
+            logger.warning(f"No content generated for this section: {title}")
+            return ""
+        else:
+            section = f"{content}"
+        urls = _aggregate_source_urls(metas)
+        sources_block = _format_sources_block(urls)
+        header = (sources_block if sources_block else "")
+        return header + section
 
+    # Recursive case: organize into headers and summarize subsections
     chunk_summaries = produce_gist(toc_path, chunks)
     headers = produce_headers(toc_path, chunk_summaries)
     topics = classify_chunks(toc_path, chunks, headers)
-    sections = group_sections(topics, chunks, headers)
-    summarized_sections = summarize_sections(toc_path, sections)
+    sections, sections_metas = _group_sections_with_metas(topics, chunks, headers, metas)
+
+    summarized_sections = summarize_sections(toc_path, sections, sections_metas)
     valid_sections = [section for section in summarized_sections if section is not None]
     if not valid_sections:
-        return f"{toc_path[-1]}\n\nNo content generated for this section."
+        logger.warning(f"No content generated for this section: {title}")
+        return ""
 
-    return toc_path[-1] + "\n\n" + "\n\n".join(valid_sections)
+    # Add a sources block for this ToC header (aggregate of all descendant chunks)
+    urls = _aggregate_source_urls(metas)
+    sources_block = _format_sources_block(urls)
+    header = (sources_block if sources_block else "")
+    return header + "\n\n".join(valid_sections)
 
 def read_markdown_file(file_path: str) -> str:
     with open(file_path) as f:
@@ -114,7 +172,7 @@ def generate_markdown_toc(markdown_text: str, toc_path: list | None = None, max_
     current_path = []
     toc_path = toc_path or []
     for line in markdown_text.splitlines():
-        match = re.match(r'^(#{1,%d})\s+(.*)', line)
+        match = re.match(fr'^(#{{1,{max_level}}})\s+(.*)', line)
         if match:
             level = len(match.group(1))
             title = match.group(2).strip()
@@ -134,7 +192,7 @@ def extract_headings(markdown_text: str, max_level: int = 3) -> list:
     """Extract headings up to max_level as a list of strings for LLM sidebar TOC."""
     headings = []
     for line in markdown_text.splitlines():
-        match = re.match(r'^(#{1,%d})\s+(.*)', line)
+        match = re.match(fr'^(#{{1,{max_level}}})\s+(.*)', line)
         if match:
             title = match.group(2).strip()
             headings.append(title)

--- a/python/src/scripts/summarizer/summarizer_factory.py
+++ b/python/src/scripts/summarizer/summarizer_factory.py
@@ -1,8 +1,8 @@
 from enum import Enum
 
 from .base_summarizer import BaseSummarizer, SummarizerConfig
-from .mdbook_summarizer import MdbookSummarizer
 from .doc_dump_summarizer import DocDumpSummarizer
+from .mdbook_summarizer import MdbookSummarizer
 
 
 class DocumentationType(Enum):

--- a/python/src/scripts/summarizer/summarizer_factory.py
+++ b/python/src/scripts/summarizer/summarizer_factory.py
@@ -2,11 +2,13 @@ from enum import Enum
 
 from .base_summarizer import BaseSummarizer, SummarizerConfig
 from .mdbook_summarizer import MdbookSummarizer
+from .doc_dump_summarizer import DocDumpSummarizer
 
 
 class DocumentationType(Enum):
     """Supported documentation types"""
     MDBOOK = "mdbook"
+    DOCDUMP = "docdump"
     # Future types can be added here
     # SPHINX = "sphinx"
     # DOCUSAURUS = "docusaurus"
@@ -17,6 +19,7 @@ class SummarizerFactory:
     
     _summarizers: dict[DocumentationType, type[BaseSummarizer]] = {
         DocumentationType.MDBOOK: MdbookSummarizer,
+        DocumentationType.DOCDUMP: DocDumpSummarizer,
     }
     
     @classmethod

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -380,6 +380,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "toml" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -448,6 +449,7 @@ requires-dist = [
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tqdm", specifier = ">=4.66.0" },
+    { name = "typer", specifier = ">=0.19.2" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.0" },
 ]
 provides-extras = ["dev"]
@@ -4852,6 +4854,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5165,6 +5176,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/94/809d85f6982841fe28526ace3b282b0458d0a96bbc6b1a982d9269a5e481/ty-0.0.1a21-py3-none-win32.whl", hash = "sha256:ecf41706b803827b0de8717f32a434dad1e67be9f4b8caf403e12013179ea06a", size = 8003866, upload-time = "2025-09-19T06:54:01.393Z" },
     { url = "https://files.pythonhosted.org/packages/50/16/b3e914cec2a6344d2c30d3780ca6ecd39667173611f8776cecfd1294eab9/ty-0.0.1a21-py3-none-win_amd64.whl", hash = "sha256:7505aeb8bf2a62f00f12cfa496f6c965074d75c8126268776565284c8a12d5dd", size = 8675300, upload-time = "2025-09-19T06:54:02.893Z" },
     { url = "https://files.pythonhosted.org/packages/16/0b/293be6bc19f6da5e9b15e615a7100504f307dd4294d2c61cee3de91198e5/ty-0.0.1a21-py3-none-win_arm64.whl", hash = "sha256:21f708d02b6588323ffdbfdba38830dd0ecfd626db50aa6006b296b5470e52f9", size = 8193800, upload-time = "2025-09-19T06:54:04.583Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- dpsy_summarizer.py
  - Added optional per-chunk metadata threading (metas) through the recursive summarization.
  - For every generated section (both leaf and non-leaf ToC headers), aggregate chunk source URLs by frequency and inject a formatted Sources: list directly under the section heading.
  - Fixed heading regex in generate_markdown_toc and extract_headings to correctly honor max_level via .
- mdbook_summarizer.py
  - Calls massively_summarize with explicit metas=None (behavior unchanged aside from ToC).
- New: doc_dump_summarizer.py
  - Reads python/doc_dump.md (or any similar doc-dump file), splits pages by “**Source URL:** …” markers, chunks per page, and passes  metadata with each chunk.
  - Uses massively_summarize to generate hierarchical summaries with per-section Sources lists.
- summarizer_factory.py
  - Added DocumentationType.DOCDUMP and registered DocDumpSummarizer.