### PR TITLE
fix(ingester): handle malformed input, support source mapping

### DIFF
--- a/ingesters/src/utils/RecursiveMarkdownSplitter.ts
+++ b/ingesters/src/utils/RecursiveMarkdownSplitter.ts
@@ -219,7 +219,9 @@ export class RecursiveMarkdownSplitter {
    * Active source becomes the first URL and applies from the end of the block
    * until the start of the next Sources block (or end of document).
    */
-  private parseSourceRanges(markdown: string): Array<{ start: number; end: number; url: string }> {
+  private parseSourceRanges(
+    markdown: string,
+  ): Array<{ start: number; end: number; url: string }> {
     const lines = markdown.split('\n');
     const ranges: Array<{ start: number; end: number; url: string }> = [];
 
@@ -247,7 +249,11 @@ export class RecursiveMarkdownSplitter {
     };
 
     // Locate all source blocks (start/end + first URL)
-    const blocks: Array<{ blockStartLine: number; blockEndLine: number; firstUrl?: string }> = [];
+    const blocks: Array<{
+      blockStartLine: number;
+      blockEndLine: number;
+      firstUrl?: string;
+    }> = [];
     for (let i = 0; i < lines.length; i++) {
       if (!isDashLine(lines[i]!)) continue;
       // Scan ahead for Sources: header within the dashed block
@@ -789,7 +795,8 @@ export class RecursiveMarkdownSplitter {
       if (i > 0 && this.options.overlap > 0) {
         const prevSegment = segments[i - 1]!;
         const desired = Math.max(
-          prevSegment.end - Math.min(this.options.overlap, prevSegment.end - prevSegment.start),
+          prevSegment.end -
+            Math.min(this.options.overlap, prevSegment.end - prevSegment.start),
           prevSegment.start,
         );
         chunkStartAbs = desired;

--- a/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.noStartInsideCodeBlock.test.ts
+++ b/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.noStartInsideCodeBlock.test.ts
@@ -1,0 +1,60 @@
+import { RecursiveMarkdownSplitter } from '../RecursiveMarkdownSplitter';
+
+function getCodeBlockRanges(text: string): Array<{ start: number; end: number }> {
+  const ranges: Array<{ start: number; end: number }> = [];
+  const re = /```[\s\S]*?```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    ranges.push({ start: m.index, end: m.index + m[0]!.length });
+  }
+  return ranges;
+}
+
+function isInside(pos: number, ranges: Array<{ start: number; end: number }>): boolean {
+  return ranges.some((r) => pos > r.start && pos < r.end);
+}
+
+describe('RecursiveMarkdownSplitter - No chunk starts inside code block', () => {
+  it('ensures chunk starts are never within fenced code blocks even with overlap', () => {
+    const longCode = Array.from({ length: 60 }, (_, i) => `line ${i} of code`).join('\n');
+    const md = `# Section One\n\nIntro paragraph text that will be part of the first section.\n\n\n## Subsection\n\nSome text before a large code block.\n\n
+\`\`\`cairo
+fn initializer(ref self: ContractState, owner: ContractAddress) {
+    // example
+    let x = 0;\n${longCode}
+}
+\`\`\`
+
+After the code block there is trailing text to encourage multiple segments and overlap across chunk boundaries. This text continues for a while to ensure we have a next chunk that might try to overlap into the previous code block.`;
+
+    const splitter = new RecursiveMarkdownSplitter({
+      maxChars: 200,
+      minChars: 0,
+      overlap: 50,
+      headerLevels: [1, 2],
+      preserveCodeBlocks: true,
+      trim: false,
+    });
+
+    const chunks = splitter.splitMarkdownToChunks(md);
+    const ranges = getCodeBlockRanges(md);
+
+    // Assert: No chunk start lies strictly inside any NON-breakable fenced code block
+    // Breakable threshold mirrors splitter default: 2x maxChars = 400
+    const codeBlockMaxChars = 400;
+    for (const c of chunks) {
+      const pos = c.meta.startChar;
+      const insideRanges = ranges.filter((r) => pos > r.start && pos < r.end);
+      if (insideRanges.length === 0) continue;
+      // If inside a code block, only allow if that block is oversized (breakable)
+      const smallest = insideRanges.reduce((acc, r) => {
+        if (!acc) return r;
+        const accLen = acc.end - acc.start;
+        const rLen = r.end - r.start;
+        return rLen < accLen ? r : acc;
+      }, insideRanges[0]!);
+      const len = (smallest?.end ?? 0) - (smallest?.start ?? 0);
+      expect(len).toBeGreaterThan(codeBlockMaxChars);
+    }
+  });
+});

--- a/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.noStartInsideCodeBlock.test.ts
+++ b/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.noStartInsideCodeBlock.test.ts
@@ -1,6 +1,8 @@
 import { RecursiveMarkdownSplitter } from '../RecursiveMarkdownSplitter';
 
-function getCodeBlockRanges(text: string): Array<{ start: number; end: number }> {
+function getCodeBlockRanges(
+  text: string,
+): Array<{ start: number; end: number }> {
   const ranges: Array<{ start: number; end: number }> = [];
   const re = /```[\s\S]*?```/g;
   let m: RegExpExecArray | null;
@@ -10,13 +12,19 @@ function getCodeBlockRanges(text: string): Array<{ start: number; end: number }>
   return ranges;
 }
 
-function isInside(pos: number, ranges: Array<{ start: number; end: number }>): boolean {
+function isInside(
+  pos: number,
+  ranges: Array<{ start: number; end: number }>,
+): boolean {
   return ranges.some((r) => pos > r.start && pos < r.end);
 }
 
 describe('RecursiveMarkdownSplitter - No chunk starts inside code block', () => {
   it('ensures chunk starts are never within fenced code blocks even with overlap', () => {
-    const longCode = Array.from({ length: 60 }, (_, i) => `line ${i} of code`).join('\n');
+    const longCode = Array.from(
+      { length: 60 },
+      (_, i) => `line ${i} of code`,
+    ).join('\n');
     const md = `# Section One\n\nIntro paragraph text that will be part of the first section.\n\n\n## Subsection\n\nSome text before a large code block.\n\n
 \`\`\`cairo
 fn initializer(ref self: ContractState, owner: ContractAddress) {

--- a/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.sourceOverlap.test.ts
+++ b/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.sourceOverlap.test.ts
@@ -1,0 +1,33 @@
+import { RecursiveMarkdownSplitter } from '../RecursiveMarkdownSplitter';
+
+describe('RecursiveMarkdownSplitter - sourceLink mapping with overlap', () => {
+  it('should use segment start (no-overlap) to resolve sourceLink so it is never undefined', () => {
+    const splitter = new RecursiveMarkdownSplitter({
+      maxChars: 60,
+      minChars: 0,
+      overlap: 20,
+      headerLevels: [1, 2, 3],
+    });
+
+    const md = `---
+
+Sources:
+
+- https://example.com/a
+
+---
+
+# Title
+
+Paragraph one is long enough to cause splitting when combined with overlap. This ensures chunk starts may fall before the source range while the segment starts after it.`;
+
+    const chunks = splitter.splitMarkdownToChunks(md);
+    expect(chunks.length).toBeGreaterThan(1);
+    // All non-ROOT chunks (after first header) should have a sourceLink
+    for (const c of chunks) {
+      if (c.meta.title !== 'ROOT') {
+        expect(c.meta.sourceLink).toBe('https://example.com/a');
+      }
+    }
+  });
+});

--- a/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.sources.test.ts
+++ b/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.sources.test.ts
@@ -1,0 +1,58 @@
+import { RecursiveMarkdownSplitter } from '../RecursiveMarkdownSplitter';
+
+describe('RecursiveMarkdownSplitter - Sources block activeSource mapping', () => {
+  it('assigns sourceLink from first URL in Sources block to subsequent chunks', () => {
+    const splitter = new RecursiveMarkdownSplitter({
+      maxChars: 120,
+      minChars: 0,
+      overlap: 0,
+      headerLevels: [1, 2],
+    });
+
+    const text = `
+  ---
+
+Sources:
+
+- https://www.starknet.io/cairo-book/ch00-00-introduction.html
+- https://www.starknet.io/cairo-book/ch00-01-foreword.html
+
+---
+
+# The Cairo Book: Introduction and Learning Resources
+
+Some introduction text.
+
+---
+
+Sources:
+
+- https://www.starknet.io/cairo-book/
+
+---
+
+## About The Cairo Book
+
+More details here.`;
+
+    const chunks = splitter.splitMarkdownToChunks(text);
+
+    // Find chunk under the first H1
+    const introChunk = chunks.find((c) =>
+      c.content.includes('# The Cairo Book: Introduction and Learning Resources'),
+    );
+    expect(introChunk).toBeDefined();
+    expect(introChunk!.meta.sourceLink).toBe(
+      'https://www.starknet.io/cairo-book/ch00-00-introduction.html',
+    );
+
+    // Find chunk under the second header (H2), after second Sources block
+    const aboutChunk = chunks.find((c) =>
+      c.content.includes('## About The Cairo Book'),
+    );
+    expect(aboutChunk).toBeDefined();
+    expect(aboutChunk!.meta.sourceLink).toBe(
+      'https://www.starknet.io/cairo-book/',
+    );
+  });
+});

--- a/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.sources.test.ts
+++ b/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.sources.test.ts
@@ -39,7 +39,9 @@ More details here.`;
 
     // Find chunk under the first H1
     const introChunk = chunks.find((c) =>
-      c.content.includes('# The Cairo Book: Introduction and Learning Resources'),
+      c.content.includes(
+        '# The Cairo Book: Introduction and Learning Resources',
+      ),
     );
     expect(introChunk).toBeDefined();
     expect(introChunk!.meta.sourceLink).toBe(

--- a/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.test.ts
+++ b/ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.test.ts
@@ -123,6 +123,26 @@ More content.`;
 
       expect(chunks[0]!.meta.title).toBe('Header with trailing hashes');
     });
+
+    it('should prefer deepest header (e.g., H3) for title', () => {
+      const splitter = new RecursiveMarkdownSplitter({
+        maxChars: 80,
+        minChars: 0,
+        overlap: 0,
+        headerLevels: [1, 2], // split only on H1/H2, but titles should use deepest header in path
+      });
+
+      const text = `# Chapter
+Intro
+
+### Specific Topic
+Detailed text that should belong to the H3.`;
+
+      const chunks = splitter.splitMarkdownToChunks(text);
+      expect(chunks.length).toBeGreaterThan(0);
+      // Title should be the deepest header in headerPath -> H3
+      expect(chunks[0]!.meta.title).toBe('Specific Topic');
+    });
   });
 
   describe('Code block handling', () => {


### PR DESCRIPTION
# Ingestion: Markdown Splitter (TypeScript)
- RecursiveMarkdownSplitter.ts
  - Added parsing of special Sources blocks delimited by `---` … `Sources:` … `---`.
  - Computes active source ranges; assigns `chunk.meta.sourceLink` to the first URL listed in the most recent Sources block for all subsequent chunks until the next block.
  - Extended `ChunkMeta` with optional `sourceLink` and tokenizer `Tokens` with `sourceRanges`.
  - Wired sourceRanges into metadata attachment without altering chunking behavior.
- Tests
  - New test: `ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.sources.test.ts` validates activeSource mapping across multiple Sources blocks.

### Splitter robustness and fallback for fenced code blocks
- Robust fenced code detection
  - Accept up to 3 leading spaces before fences.
  - Track fence char and exact length; closing fence must match char and have length ≥ open, fence-only (no info string).
  - Fallback-close a malformed open block when a new opening fence appears while still in a block (marks previous as breakable).
  - Mark unclosed-at-EOF blocks as `breakable: true`.
- Breakable blocks and size threshold
  - New `SplitOptions`:
    - `codeBlockMaxChars` (default: 2× `maxChars`) — closed blocks larger than this are treated as breakable (splittable).
    - `fallbackCloseOnNestedOpen` (default: true).
- Splitting rules updated
  - Paragraph/line splitting skips split points only inside non-breakable blocks; allows splits inside breakable blocks.
  - Final boundary pass adjusts segment starts/ends only for non-breakable blocks; ensures monotonic, non-overlapping segments.
  - Overlap start is pushed past block end only if the enclosing block is non-breakable.
- Tests
  - New: `ingesters/src/utils/__tests__/RecursiveMarkdownSplitter.noStartInsideCodeBlock.test.ts` enforces that no chunk starts inside a non-breakable code block; allows starts inside breakable (malformed/oversized) blocks.